### PR TITLE
With Basic Auth secrets shouldn't be sent.

### DIFF
--- a/oauth2.js
+++ b/oauth2.js
@@ -93,7 +93,11 @@ module.exports = function (RED) {
         // TODO - ??? =)
         Authorization = 'Basic ' + Buffer.from(`${node.client_id}:${node.client_secret}`).toString('base64');
       }
-
+      //When the clients secret and password are passed to the as Authorization Basic for many API's it shouldn't shouldn't be sent in form.
+      delete Form.client_secret;
+      delete Form.client_id;
+      delete Form.username;
+      delete Form.password;
       let Body = querystring.stringify(Form);
 
       // set Headers


### PR DESCRIPTION
I noticed that sending the client_secret causes issues with OBO's OAuth2 implementation. Maybe this should be a flag in the node object but, there needs to be a way to disable sending the secret data in form Body.