### PR TITLE
Fix bugs in status code check, request headers in password grant, and request body in client credentials

### DIFF
--- a/oauth2.js
+++ b/oauth2.js
@@ -100,7 +100,9 @@ module.exports = function (RED) {
           grant_type: node.grant_type,
           client_id: node.client_id,
           client_secret: node.client_secret,
-          scope: node.scope,
+        };
+        if (node.scope.length > 0) {
+          Form.scope = node.scope
         };
         // TODO - ??? =)
         Authorization =

--- a/oauth2.js
+++ b/oauth2.js
@@ -109,11 +109,9 @@ module.exports = function (RED) {
             "base64"
           );
       }
-      //When the clients secret and password are passed to the as Authorization Basic for many API's it shouldn't shouldn't be sent in form.
+      //When the client secret and client id are passed to the as Authorization Basic for many API's it shouldn't shouldn't be sent in form.
       delete Form.client_secret;
       delete Form.client_id;
-      delete Form.username;
-      delete Form.password;
       let Body = querystring.stringify(Form);
 
       // set Headers

--- a/oauth2.js
+++ b/oauth2.js
@@ -147,7 +147,7 @@ module.exports = function (RED) {
         if (msg.oauth2Request) delete msg.oauth2Request;
         try {
           let oauth2Body = JSON.parse(body ? body : JSON.stringify("{}"));
-          if (response && response.statusCode < 299 && response.statusCode > 200)  {
+          if (response && response.statusCode < 299 && response.statusCode > 199)  {
             msg[node.container] = {
               authorization: `${oauth2Body.token_type} ${oauth2Body.access_token}`,
               oauth2Response: {


### PR DESCRIPTION
I fixed the following bugs.

* The oauth response is not output from the node when the response status code is 200.
  * I fixed the status code checking logic to treat 200 response (fix  caputomarcos/node-red-contrib-oauth2#16).
* In the password grant, the username and password are not sent to the authorization server.
  * I fixed the request body in the password grant to include username and password.
* In the client credentials grant, if no scope is provided to the node, the request body may be regarded as bad request in the authorization server.
  * I fixed the request body in the client credentials grant not to include the scope field if no scope is provided to the node.

I tested that the node can successfully fetch and output tokens in both password grant and client credentials grant in the following environment.
* Node-RED 1.2.7
* Keycloak 12.0.2