### PR TITLE
Add support for Azure Auth Code flow

### DIFF
--- a/locales/en-US/oauth2.json
+++ b/locales/en-US/oauth2.json
@@ -14,7 +14,8 @@
             "client_id": "Client ID",
             "client_secret": "Client Secret",
             "scope": "Scope",
-            "rejectUnauthorized" : "rejectUnauthorized"
+            "rejectUnauthorized" : "rejectUnauthorized",
+            "client_credentials_in_body": "Include client credentials in token request body"
         },
         "placeholder":{
             "name": "oauth2",

--- a/oauth2.html
+++ b/oauth2.html
@@ -220,14 +220,14 @@
           const authorizationEndpoint = $("#node-input-authorization_endpoint").val();
           const clientId              = $("#node-input-client_id").val();
           const clientSecret          = $("#node-input-client_secret").val();
-          var scopes                  = $("#node-input-scope").val();
-          scopes = scopes.replace(/\n/g, "%20");
-          
+          var scope                   = $("#node-input-scope").val();
+          scope = scope.replace(/\n/g, "%20");
+
           var url;
           if (authorizationEndpoint) {
-            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scopes=${scopes}&callback=${encodeURIComponent(callback)}&authorizationEndpoint=${encodeURIComponent(authorizationEndpoint)}&redirectUri=${redirectUri}`;
+            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}&authorizationEndpoint=${encodeURIComponent(authorizationEndpoint)}&redirectUri=${redirectUri}`;
           } else {
-            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scopes=${scopes}&callback=${encodeURIComponent(callback)}`;
+            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}`;
           }
           
           $(this).attr("href",url);

--- a/oauth2.html
+++ b/oauth2.html
@@ -70,6 +70,11 @@
 
     <!-- <button class="red-ui-button" id="authorizeButton" style="right: 0px; top: 0px;"><i class="fa fa-key"></i> Authorize</button> -->
   </div>
+  <!-- node-client_credentials_in_body -->
+  <div class="form-row" id="node-client_credentials_in_body">
+    <label for="node-input-client_credentials_in_body"><i class="fa fa-sign-in fa-fw"></i> <span data-i18n="oauth2.label.client_credentials_in_body"></span></label>
+    <input type="checkbox" id="node-input-client_credentials_in_body">
+  </div>
   <!-- node-rejectUnauthorized -->
   <div class="form-row" id="node-rejectUnauthorized">
       <label for="node-input-rejectUnauthorized" style="width:30%;"><i class="fa fa-exclamation-circle fa-fw" ></i> <span data-i18n="oauth2.label.rejectUnauthorized"></span></label>
@@ -119,6 +124,7 @@
       client_id: {value: ""},
       client_secret: {value: ""},
       scope: {value: ""},
+      client_credentials_in_body: {value: false},
       rejectUnauthorized : {value: true},
       headers: {value:{}}
     },
@@ -170,6 +176,7 @@
           $("#node-client_secret").hide();
           $("#node-scope").hide();
 	        $("#node-rejectUnauthorized").hide();
+          $("#node-client_credentials_in_body").hide();
         } else if ($("#node-input-grant_type").val() === "client_credentials") {
           $("#node-authorization_endpoint").hide();
           $("#node-open_authentication").hide();
@@ -180,6 +187,7 @@
           $("#node-client_secret").show();
           $("#node-scope").show();
 	        $("#node-rejectUnauthorized").show();
+          $("#node-client_credentials_in_body").hide();
         } else if ($("#node-input-grant_type").val() === "password") {
           $("#node-authorization_endpoint").hide();
           $("#node-open_authentication").hide();
@@ -190,6 +198,7 @@
           $("#node-client_secret").show();
           $("#node-scope").show();
 	        $("#node-rejectUnauthorized").show();
+          $("#node-client_credentials_in_body").hide();
         } else if ($("#node-input-grant_type").val() === "authorization_code") {
           $("#node-password_credentials").hide();
           $("#node-open_authentication").show();
@@ -200,6 +209,7 @@
           $("#node-client_secret").show();
           $("#node-scope").show();
 	        $("#node-rejectUnauthorized").hide();
+          $("#node-client_credentials_in_body").show();
         }
       });
 

--- a/oauth2.js
+++ b/oauth2.js
@@ -201,7 +201,9 @@
       "setTimeout(\"closeWindow()\", 1000);\n" +
       "}\n" +
       "</script></HEAD>" +
-      "<BODY onload=\"javascript:delay();\"></BODY></HTML>";
+      "<BODY onload=\"javascript:delay();\">" +
+      "<p>Success! This page can be closed if it doesn't do so automatically.</p>"
+      "</BODY></HTML>";
 
       res.send(html);  
     }

--- a/oauth2.js
+++ b/oauth2.js
@@ -117,7 +117,12 @@
             options.form.password = node.password;
           };
           if (node.grant_type === "authorization_code") {
+            // Some services accept these via Authorization while other require it in the POST body
+            options.form.client_id = node.client_id;
+            options.form.client_secret = node.client_secret
+
             options.form.code = node.credentials.code;
+            options.form.redirect_uri = node.credentials.redirectUri;
           };
         };
 
@@ -182,7 +187,7 @@
 
   RED.httpAdmin.get('/oauth2/credentials/:token', function(req, res) {
     var credentials = RED.nodes.getCredentials(req.params.token);
-    res.json({code: credentials.code});
+    res.json({code: credentials.code, redirect_uri: credentials.redirect_uri});
   });
 
   RED.httpAdmin.get('/oauth2/redirect', function(req, res) {
@@ -225,6 +230,7 @@
     
     credentials.csrfToken = csrfToken;
     credentials.callback = callback;
+    credentials.redirectUri = redirectUri;
     res.cookie('csrf', csrfToken);
     var l = url.parse(req.query.authorizationEndpoint, true);
     res.redirect(url.format({

--- a/oauth2.js
+++ b/oauth2.js
@@ -60,6 +60,7 @@
       this.client_secret = oauth2Node.client_secret || "";
       this.scope = oauth2Node.scope || "";
       this.rejectUnauthorized = oauth2Node.rejectUnauthorized || false;
+      this.client_credentials_in_body = oauth2Node.client_credentials_in_body || false;
       this.headers = oauth2Node.headers || {};
 
       // copy "this" object in case we need it in context of callbacks of other functions.
@@ -118,8 +119,10 @@
           };
           if (node.grant_type === "authorization_code") {
             // Some services accept these via Authorization while other require it in the POST body
-            options.form.client_id = node.client_id;
-            options.form.client_secret = node.client_secret
+            if (node.client_credentials_in_body) {
+              options.form.client_id = node.client_id;
+              options.form.client_secret = node.client_secret;
+            }
 
             options.form.code = node.credentials.code;
             options.form.redirect_uri = node.credentials.redirectUri;

--- a/oauth2.js
+++ b/oauth2.js
@@ -218,7 +218,7 @@
     const callback = req.query.callback;
     const redirectUri = req.query.redirectUri;
     const credentials = JSON.parse(JSON.stringify(req.query, getCircularReplacer()))
-    const scopes = req.query.scopes;
+    const scope = req.query.scope;
     const csrfToken = crypto.randomBytes(18).toString('base64').replace(/\//g, '-').replace(/\+/g, '_');
     
     credentials.csrfToken = csrfToken;
@@ -232,7 +232,8 @@
       query: {
           client_id: credentials.clientId,
           redirect_uri: redirectUri,
-          state: node_id + ":" + csrfToken
+          state: node_id + ":" + csrfToken,
+          scope: scope
       }
     }));
     RED.nodes.addCredentials(node_id, credentials);

--- a/oauth2.js
+++ b/oauth2.js
@@ -233,7 +233,8 @@
           client_id: credentials.clientId,
           redirect_uri: redirectUri,
           state: node_id + ":" + csrfToken,
-          scope: scope
+          scope: scope,
+          response_type: 'code'
       }
     }));
     RED.nodes.addCredentials(node_id, credentials);


### PR DESCRIPTION
This should resolve the issues highlighted in my comment in #27 with Azure AD. Some of this is mandatory in requests for `authorization_code` grant types so should also be applicable/fix other implementations.

I believe the only Azure specific part is that `client_id` and `client_secret` must be in the body of the POST request when exchanging a token. This seems to be a provider decision on how to accept it (but not exclusive to Azure) so I added an option for it in the settings.

Exchanging the code for an access token invalidates the code (in azure at least) so any flows using this will need to store the refresh token. This can then be used to get a new access token. In future, it might be worth making this an automatic process (store refresh token on first use, then use refresh token if it exists), but for now this is working enough to use in flows.