### PR TITLE
 ReferenceError: https is not defined #43 

### DIFF
--- a/oauth2.js
+++ b/oauth2.js
@@ -24,11 +24,14 @@
  **/
 
  module.exports = function (RED) {
+  
   "use strict";
+
   // require any external libraries we may need....
   const axios = require('axios');
   const url = require('url');
   const crypto = require("crypto");
+  const https = require('https');
 
   const getCircularReplacer = () => {
     const seen = new WeakSet();


### PR DESCRIPTION
The error ReferenceError: https is not defined occurs because https module has not been required in the file.

```js
const https = require('https');
```
This should fix the error.