### PR TITLE
 ERR DEPTH_ZERO_SELF_SIGNED_CERT #44

### DIFF
--- a/oauth2.js
+++ b/oauth2.js
@@ -24,11 +24,14 @@
  **/
 
  module.exports = function (RED) {
+  
   "use strict";
+
   // require any external libraries we may need....
   const axios = require('axios');
   const url = require('url');
   const crypto = require("crypto");
+  const https = require('https');
 
   const getCircularReplacer = () => {
     const seen = new WeakSet();
@@ -141,7 +144,7 @@
         // make a post request
         axios.post(options.url, options.form, {
           headers: options.headers,
-          httpsAgent: node.rejectUnauthorized ? new https.Agent({ rejectUnauthorized: true }) : undefined,
+          httpsAgent: node.rejectUnauthorized ? new https.Agent({ rejectUnauthorized: true }) : new https.Agent({}),
         })
           .then(response => {
             msg[node.container] = response.data || {};


### PR DESCRIPTION
@rmwiseman 

This pull request fixes the "ERR_DEPT_ZERO_SELF_SIGNED_CERT" error in the OAuth2 node of the Node-RED instance. The issue was caused by a missing https module import and the use of a self-signed certificate in the HTTPS connection. To fix this, I added the missing https import and modified the axios.post call to use a new instance of the https.Agent class with the rejectUnauthorized option set to the value of node.rejectUnauthorized. This allows the node to handle self-signed certificates properly without rejecting them.

kind regards