### PR TITLE
44 err depth zero self signed cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
+.vscode
 /node_modules
 /lib
+index.html

--- a/oauth2.js
+++ b/oauth2.js
@@ -145,7 +145,7 @@ module.exports = function (RED) {
         // make a post request
         axios.post(options.url, options.form, {
           headers: options.headers,
-          httpsAgent: node.rejectUnauthorized ? new https.Agent({ rejectUnauthorized: true }) : new https.Agent({}),
+          httpsAgent: node.rejectUnauthorized ? new https.Agent({ rejectUnauthorized: true }) : new https.Agent({ rejectUnauthorized: false }),
         })
           .then(response => {
             msg[node.container] = response.data || {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-oauth2",
-  "version": "4.1.1",
+  "version": "4.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-oauth2",
-      "version": "4.1.1",
+      "version": "4.1.5",
       "license": "MIT License",
       "dependencies": {
         "axios": ">=1.3.3",
@@ -25,9 +25,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-oauth2",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "The node-red-contrib-oauth2 is a Node-RED node that provides an OAuth2 authentication flow. This node uses the OAuth2 protocol to obtain an access token, which can be used to make authenticated API requests.",
   "author": "Marcos Caputo <caputo.marcos@gmail.com>",
   "contributors": [],


### PR DESCRIPTION
Review of Pull Request #50 for node-red-contrib-oauth2

Overall, the change is simple and appears to achieve its objective of disabling certificate validation for HTTPS requests. Additionally, the author fixes the package version inconsistency.

There are no syntax issues found in the patch.

Here are some points regarding the changes made:

The change made in .gitignore looks good. It added the index.html file to the ignore list.
In oauth2.js, the changes made to the httpsAgent option look correct. Now, if rejectUnauthorized is true, a new https.Agent object will be created with { rejectUnauthorized: true }. Otherwise, a new https.Agent object will be created with { rejectUnauthorized: false }.
In package-lock.json, the author updated the version of axios from 1.3.3 to 1.3.4 and also updated the version of node-red-contrib-oauth2 to 4.1.5 to match the version in package.json.
Given these observations, the change appears to be a useful and concise update to the repository. The patch looks ready to be merged.