### PR TITLE
 updated to include new keys use-proxy, proxy-config, and senderr

### DIFF
--- a/.github/workflows/codeball.yml
+++ b/.github/workflows/codeball.yml
@@ -1,0 +1,19 @@
+name: Codeball
+on:
+  pull_request: {}
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  codeball_job:
+    runs-on: ubuntu-latest
+    name: Codeball
+    steps:
+      - name: Codeball
+        uses: sturdy-dev/codeball-action@v2
+        with:
+          # For all configuration options see https://github.com/sturdy-dev/codeball-action/blob/v2/action.yml
+          approvePullRequests: "true"
+          labelPullRequestsWhenApproved: "true"
+          labelPullRequestsWhenReviewNeeded: "false"
+          failJobsWhenReviewNeeded: "false"

--- a/.github/workflows/codeball.yml
+++ b/.github/workflows/codeball.yml
@@ -1,19 +1,136 @@
-name: Codeball
-on:
-  pull_request: {}
-  pull_request_review_comment:
-    types: [created, edited]
+# See https://github.com/sturdy-dev/codeball-action for more information of how to use this action
+name: Codeball AI Code Review
+description: AI Code Review – Codeball approves Pull Requests that a human would have approved. Wait less for review, save time and money.
 
-jobs:
-  codeball_job:
-    runs-on: ubuntu-latest
-    name: Codeball
-    steps:
-      - name: Codeball
-        uses: sturdy-dev/codeball-action@v2
-        with:
-          # For all configuration options see https://github.com/sturdy-dev/codeball-action/blob/v2/action.yml
-          approvePullRequests: "true"
-          labelPullRequestsWhenApproved: "true"
-          labelPullRequestsWhenReviewNeeded: "false"
-          failJobsWhenReviewNeeded: "false"
+author: Sturdy
+branding:
+  icon: check
+  color: orange
+
+inputs:
+  approvePullRequests:
+    description: 'If "true", the action will submit an approving review if the Codeball AI approves the contribution'
+    default: "true"
+    required: false
+
+  labelPullRequestsWhenApproved:
+    description: 'If "true", the action will add `codeball:approved` label to the PR if the Codeball AI confidence is above the configured approve threshold'
+    default: "true"
+    required: false
+
+  labelPullRequestsWhenReviewNeeded:
+    description: 'If "true", the action will add `codeball:needs-review` label to the PR if the Codeball AI confidence is between the "approve" and "careful" thresholds'
+    default: "false"
+    required: false
+
+  labelPullRequestsWhenCarefulReviewNeeded:
+    description: 'If "true", the action will add `codeball:needs-careful-review` label to the PR if the Codeball AI confidence is below the configured careful threshold'
+    default: "true"
+    required: false
+
+  approveThreshold:
+    description: 'The threshold to use for "approving" (greater than or equal to). A number between 0 and 1. Must be specified with 3 decimals.'
+    default: "0.935"
+    required: false
+
+  carefulReviewThreshold:
+    description: 'The threshold to use for "careful review" actions (less than). A number between 0 and 1. Must be specified with 3 decimals.'
+    default: "0.300"
+    required: false
+
+  failJobsWhenReviewNeeded:
+    description: 'If "true", the action will exit with status code 1 if the Codeball AI does not approve the contribution'
+    default: "false"
+    required: false
+
+  codeSuggestionsFromComments:
+    description: 'If "true", Codeball will read generate code suggestions from comments made in Pull Requests (beta)'
+    default: "false"
+    required: false
+
+  GITHUB_TOKEN:
+    description: 'Default to {{ github.token }}. This is the default GitHub token available to actions and is used to run Codeball and to post the result. The default token permissions (https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions) work fine.'
+    default: '${{ github.token }}'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+
+    # Start a new Codeball review job
+    # This step is asynchronous and will return a job id
+    - name: Trigger Codeball
+      id: codeball_baller
+      uses: sturdy-dev/codeball-action/baller@v2
+      with:
+        approveThreshold: ${{ inputs.approveThreshold }}
+        carefulReviewThreshold: ${{ inputs.carefulReviewThreshold }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+    # Wait for Codeball to return the status
+    - name: Get Status
+      id: codeball_status
+      uses: sturdy-dev/codeball-action/status@v2
+      with:
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+
+    # If the Codeball confidence is high, add the "codeball:approved" label
+    - name: Label Approved
+      uses: sturdy-dev/codeball-action/labeler@v2
+      if: ${{ steps.codeball_status.outputs.jobType == 'contribution' && inputs.labelPullRequestsWhenApproved == 'true' && steps.codeball_status.outputs.confidence >= inputs.approveThreshold  }}
+      with:
+        name: "codeball:approved"
+        color: "86efac" # green
+        remove-label-names: "codeball:needs-review,codeball:needs-careful-review"
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+
+    # If the Codeball confidence is medium, add the "codeball:needs-review" label
+    - name: Label Needs Review
+      uses: sturdy-dev/codeball-action/labeler@v2
+      if: ${{ steps.codeball_status.outputs.jobType == 'contribution' && inputs.labelPullRequestsWhenReviewNeeded == 'true' && steps.codeball_status.outputs.confidence >= inputs.carefulReviewThreshold && steps.codeball_status.outputs.confidence < inputs.approveThreshold  }}
+      with:
+        name: "codeball:needs-review"
+        color: "bfdbfe" # blue
+        remove-label-names: "codeball:approved,codeball:needs-careful-review"
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+
+    # If the Codeball confidence is low, add the "codeball:needs-careful-review" label
+    - name: Label Needs Careful Review
+      uses: sturdy-dev/codeball-action/labeler@v2
+      if: ${{ steps.codeball_status.outputs.jobType == 'contribution' && inputs.labelPullRequestsWhenCarefulReviewNeeded == 'true' && steps.codeball_status.outputs.confidence < inputs.carefulReviewThreshold }}
+      with:
+        name: "codeball:needs-careful-review"
+        color: "fde68a" # amber
+        remove-label-names: "codeball:approved,codeball:needs-review"
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+
+    # If Codeball approved the contribution, approve the PR
+    - name: Approve PR
+      uses: sturdy-dev/codeball-action/approver@v2
+      if: ${{ steps.codeball_status.outputs.jobType == 'contribution' && inputs.approvePullRequests == 'true' }}
+      with:
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+        approve: ${{ steps.codeball_status.outputs.confidence >= inputs.approveThreshold }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+    # If Codeball have code suggestions, add suggestions as comments
+    - name: Add Suggestions
+      uses: sturdy-dev/codeball-action/suggester@v2
+      if: ${{ steps.codeball_status.outputs.suggested == 'true' && inputs.codeSuggestionsFromComments == 'true' && steps.codeball_status.outputs.jobType == 'comment' }}
+      with:
+        codeball-job-id: ${{ steps.codeball_baller.outputs.codeball-job-id }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+
+    # If Codeball didn't approve the contribution, fail the job.
+    - name: Fail Job
+      shell: bash
+      if: ${{ steps.codeball_status.outputs.approved == 'false' && inputs.failJobsWhenReviewNeeded == 'true' && steps.codeball_status.outputs.jobType == 'contribution' }}
+      run: |
+        echo "Not approved"
+        exit 1

--- a/locales/en-US/oauth2.json
+++ b/locales/en-US/oauth2.json
@@ -27,7 +27,7 @@
             "access_token_url": "https://github.com/login/oauth/access_token",
             "authorization_endpoint": "https://github.com/login/oauth/authorize",
             "redirect_uri": "/oauth2/redirect",
-            "open_authentication": "93af6282be5",
+            "open_authentication": "1b897416-3de3-4631-a0e9-7f7431e1a959",
             "username": "admin",
             "password": "admin",
             "client_id": "012493af6282be51660dbc8e21a8462e",

--- a/locales/en-US/oauth2.json
+++ b/locales/en-US/oauth2.json
@@ -14,12 +14,15 @@
             "client_id": "Client ID",
             "client_secret": "Client Secret",
             "scope": "Scope",
-            "rejectUnauthorized" : "The rejectUnauthorized parameter controls SSL/TLS certificate validation for the server, with true enforcing validation and false disabling it.",
-            "rejectUnauthorized_label" : "Reject Unauthorized",
+            "rejectUnauthorized": "The rejectUnauthorized parameter controls SSL/TLS certificate validation for the server, with true enforcing validation and false disabling it.",
+            "rejectUnauthorized_label": "Reject Unauthorized",
             "client_credentials_in_body": "Ensure that the client credentials are included in the token request body for authentication purposes.",
-            "client_credentials_in_body_label": "Embedded Credentials"
+            "client_credentials_in_body_label": "Embedded Credentials",
+            "proxy-config": "Proxy Configuration",
+            "use-proxy": "Use proxy",
+            "senderr": "Only send non-2xx responses to Catch node"
         },
-        "placeholder":{
+        "placeholder": {
             "name": "oauth2",
             "access_token_url": "https://github.com/login/oauth/access_token",
             "authorization_endpoint": "https://github.com/login/oauth/authorize",
@@ -30,7 +33,7 @@
             "client_id": "012493af6282be51660dbc8e21a8462e",
             "client_secret": "5621bd4b5a8b09ed31817efb8d54fda2c72bfc1c6968cd4563d83f7cc26f68f6",
             "scope": "scope",
-            "rejectUnauthorized" : "rejectUnauthorized",
+            "rejectUnauthorized": "rejectUnauthorized",
             "headers": "headers"
         },
         "opts": {

--- a/oauth2.html
+++ b/oauth2.html
@@ -38,9 +38,11 @@
 </div>
 <!-- node-redirect_uri -->
 <!-- <div class="form-row" id="node-redirect_uri">
-    <label for="node-input-redirect_uri"><i class="fa fa-link fa-fw"></i> <span data-i18n="oauth2.label.redirect_uri"></span></label>
-    <input type="text" id="node-input-redirect_uri" data-i18n="[placeholder]oauth2.placeholder.redirect_uri" style="width:70%;">
-  </div> -->
+  <label for="node-input-redirect_uri"><i class="fa fa-link fa-fw"></i> <span
+      data-i18n="oauth2.label.redirect_uri"></span></label>
+  <input type="text" id="node-input-redirect_uri" data-i18n="[placeholder]oauth2.placeholder.redirect_uri"
+    style="width:70%;">
+</div> -->
 <!-- node-password_credentials -->
 <div class="form-row" id="node-password_credentials">
   <!--node-input-username -->
@@ -83,6 +85,22 @@
   <input type="text" id="node-input-open_authentication" data-i18n="[placeholder]oauth2.placeholder.open_authentication"
     style="width:61%;margin-top: -4px;" disabled>
 </div>
+
+<div class="form-row">
+  <input type="checkbox" id="node-input-useProxy" style="display: inline-block; width: auto; vertical-align: top;">
+  <label for="node-input-useProxy" style="width: auto;"><span data-i18n="oauth2.label.use-proxy"></span></label>
+  <div id="node-input-useProxy-row" class="hide">
+    <label style="width: auto; margin-left: 20px; margin-right: 10px;" for="node-input-proxy"><i
+        class="fa fa-globe"></i> <span data-i18n="oauth2.label.proxy-config"></span></label><input type="text"
+      style="width: 270px" id="node-input-proxy">
+  </div>
+</div>
+
+<div class="form-row">
+  <input type="checkbox" id="node-input-senderr" style="display: inline-block; width: auto; vertical-align: top;">
+  <label for="node-input-senderr" style="width: auto" data-i18n="oauth2.label.senderr"></label>
+</div>
+
 <!-- node-client_credentials_in_body -->
 <div class="form-row" id="node-client_credentials_in_body">
   <div abria-label="Info for context store" class="form-row form-tips node-help" style="width:100%">
@@ -156,6 +174,11 @@
         client_id: { value: "" },
         client_secret: { value: "" },
         scope: { value: "" },
+        proxy: {
+          type: "http proxy", required: false,
+          label: RED._("node-red:oauth2.label.proxy-config")
+        },
+        senderr: { value: false },
         client_credentials_in_body: { value: false },
         rejectUnauthorized: { value: true },
         headers: { value: {} }
@@ -187,7 +210,6 @@
         } else {
           callback = `${location.protocol}//${location.hostname}${(location.port ? ":" + location.port : "")}${pathname}oauth2/auth/callback`;
         }
-
 
         var redirectUri = `${location.protocol}//${location.hostname}${(location.port ? ":" + location.port : "")}${pathname}oauth2/redirect`;
 
@@ -249,11 +271,10 @@
         function pollCredentials() {
           $.getJSON('oauth2/credentials/' + id, function (data) {
             if (data) {
-              console.log(data);
               $("#node-input-open_authentication").val(data.code);
               delete window.configNodeIntervalId;
             } else {
-              window.configNodeIntervalId = window.setTimeout(pollCredentials, 2000);
+              window.configNodeIntervalId = window.setTimeout(pollCredentials, 5000);
             }
           });
         };
@@ -262,19 +283,20 @@
           const authorizationEndpoint = $("#node-input-authorization_endpoint").val();
           const clientId = $("#node-input-client_id").val();
           const clientSecret = $("#node-input-client_secret").val();
+          const proxy = $("#node-input-proxy").val();
           var scope = $("#node-input-scope").val();
           scope = scope.replace(/\n/g, "%20");
 
           var url;
           if (authorizationEndpoint) {
-            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}&authorizationEndpoint=${encodeURIComponent(authorizationEndpoint)}&redirectUri=${redirectUri}`;
+            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}&authorizationEndpoint=${encodeURIComponent(authorizationEndpoint)}&redirectUri=${redirectUri}&proxy=${proxy}`;
           } else {
-            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}`;
+            url = `oauth2/auth?id=${id}&clientId=${clientId}&clientSecret=${clientSecret}&scope=${scope}&callback=${encodeURIComponent(callback)}&proxy=${proxy}`;
           }
 
           $(this).attr("href", url);
 
-          window.configNodeIntervalId = window.setTimeout(pollCredentials, 2000);
+          window.configNodeIntervalId = window.setTimeout(pollCredentials, 5000);
 
         });
         $("#authorizeButton").click(function () {
@@ -284,6 +306,25 @@
             e.preventDefault();
           }
         });
+
+        $("#node-input-useProxy").on("click", function () {
+          updateProxyOptions();
+        });
+        function updateProxyOptions() {
+          if ($("#node-input-useProxy").is(":checked")) {
+            $("#node-input-useProxy-row").show();
+          } else {
+            $("#node-input-useProxy-row").hide();
+          }
+          RED.tray.resize();
+        }
+        if (this.proxy) {
+          $("#node-input-useProxy").prop("checked", true);
+        } else {
+          $("#node-input-useProxy").prop("checked", false);
+        }
+        updateProxyOptions();
+
         var headerList = $("#node-input-headers-container").css('min-height', '150px').css('min-width', '450px').editableList({
           addItem: function (container, i, header) {
             var row = $('<div/>').css({
@@ -360,6 +401,9 @@
         }
       },
       oneditsave: function () {
+        if (!$("#node-input-useProxy").is(":checked")) {
+          $("#node-input-proxy").val("_ADD_");
+        }
         var headers = $("#node-input-headers-container").editableList('items');
         var node = this;
         node.headers = {};

--- a/oauth2.js
+++ b/oauth2.js
@@ -28,15 +28,22 @@ module.exports = function (RED) {
   "use strict";
 
   // require any external libraries we may need....
-  const axios = require('axios');
-  const url = require('url');
+  const axios = require("axios");
+  const url = require("url");
   const crypto = require("crypto");
-  const https = require('https');
+  const https = require("https");
 
+  /**
+   * This function replaces circular references in the provided object to allow
+   * safe stringification.
+   *
+   * @param {object} obj - The object to check for circular references
+   * @returns {object} The object with circular references replaced
+   */
   const getCircularReplacer = () => {
     const seen = new WeakSet();
     return (key, value) => {
-      if (typeof value === 'object' && value !== null) {
+      if (typeof value === "object" && value !== null) {
         if (seen.has(value)) {
           return;
         }
@@ -46,8 +53,20 @@ module.exports = function (RED) {
     };
   };
 
-  // The main node definition - most things happen in here
+  /**
+   * OAuth2Node class represents a custom node used in the Node-RED flow-based programming platform.
+   * The node handles authentication with OAuth 2.0 servers by generating tokens required for API access.
+   *
+   * The main node definition - most things happen in here!
+   * @class
+   */
+
   class OAuth2Node {
+    /**
+     * Constructor for OAuth2Node.
+     * @constructor
+     * @param {Object} oauth2Node - The configuration for the node.
+     */
     constructor(oauth2Node) {
       // Create a RED node
       RED.nodes.createNode(this, oauth2Node);
@@ -63,15 +82,26 @@ module.exports = function (RED) {
       this.client_secret = oauth2Node.client_secret || "";
       this.scope = oauth2Node.scope || "";
       this.rejectUnauthorized = oauth2Node.rejectUnauthorized || false;
-      this.client_credentials_in_body = oauth2Node.client_credentials_in_body || false;
+      this.client_credentials_in_body =
+        oauth2Node.client_credentials_in_body || false;
       this.headers = oauth2Node.headers || {};
       this.sendErrorsToCatch = oauth2Node.senderr || false;
 
-      if (process.env.http_proxy) { this.prox = process.env.http_proxy; }
-      if (process.env.HTTP_PROXY) { this.prox = process.env.HTTP_PROXY; }
-      if (process.env.no_proxy) { this.noprox = process.env.no_proxy.split(","); }
-      if (process.env.NO_PROXY) { this.noprox = process.env.NO_PROXY.split(","); }
+      // Check environment variables for proxy settings
+      if (process.env.http_proxy) {
+        this.prox = process.env.http_proxy;
+      }
+      if (process.env.HTTP_PROXY) {
+        this.prox = process.env.HTTP_PROXY;
+      }
+      if (process.env.no_proxy) {
+        this.noprox = process.env.no_proxy.split(",");
+      }
+      if (process.env.NO_PROXY) {
+        this.noprox = process.env.NO_PROXY.split(",");
+      }
 
+      // Set proxyConfig variable if node has a proxy configuration
       let proxyConfig;
       if (oauth2Node.proxy) {
         proxyConfig = RED.nodes.getNode(oauth2Node.proxy);
@@ -82,57 +112,66 @@ module.exports = function (RED) {
       // copy "this" object in case we need it in context of callbacks of other functions.
       let node = this;
 
-      // respond to inputs....
-      this.on("input", function (msg, nodeSend, nodeDone) {
+      /**
+       * Responds to inputs.
+       * @function
+       * @param {object} msg - The input message object.
+       * @param {function} Send - The callback function for sending messages to next nodes.
+       * @param {function} Done - The callback function to end the node's processing.
+       */
+      this.on("input", function (msg, Send, Done) {
         // generate the options for the request
-        let options = {}
+        let options = {};
         if (node.grant_type === "set_by_credentials") {
           options = {
-            'method': 'POST',
-            'url': msg.oauth2Request.access_token_url,
-            'headers': {
-              'Authorization': "Basic " +
-                Buffer.from(`${msg.oauth2Request.credentials.client_id}:${msg.oauth2Request.credentials.client_secret}`).toString(
-                  "base64"
-                ),
-              'Content-Type': 'application/x-www-form-urlencoded',
-              'Accept': 'application/json',
+            method: "POST",
+            url: msg.oauth2Request.access_token_url,
+            headers: {
+              Authorization:
+                "Basic " +
+                Buffer.from(
+                  `${msg.oauth2Request.credentials.client_id}:${msg.oauth2Request.credentials.client_secret}`
+                ).toString("base64"),
+              "Content-Type": "application/x-www-form-urlencoded",
+              Accept: "application/json",
             },
-            'rejectUnauthorized': node.rejectUnauthorized,
+            rejectUnauthorized: node.rejectUnauthorized,
             form: {
-              'grant_type': msg.oauth2Request.credentials.grant_type,
-              'scope': msg.oauth2Request.credentials.scope
-            }
+              grant_type: msg.oauth2Request.credentials.grant_type,
+              scope: msg.oauth2Request.credentials.scope,
+            },
           };
           if (msg.oauth2Request.credentials.grant_type === "password") {
             options.form.username = msg.oauth2Request.credentials.username;
             options.form.password = msg.oauth2Request.credentials.password;
-          };
+          }
           if (msg.oauth2Request.credentials.grant_type === "refresh_token") {
-            options.form.refresh_token = msg.oauth2Request.credentials.refresh_token;
+            options.form.refresh_token =
+              msg.oauth2Request.credentials.refresh_token;
           }
         } else {
           options = {
-            'method': 'POST',
-            'url': node.access_token_url,
-            'headers': {
-              'Authorization': "Basic " +
+            method: "POST",
+            url: node.access_token_url,
+            headers: {
+              Authorization:
+                "Basic " +
                 Buffer.from(`${node.client_id}:${node.client_secret}`).toString(
                   "base64"
                 ),
-              'Content-Type': 'application/x-www-form-urlencoded',
-              'Accept': 'application/json'
+              "Content-Type": "application/x-www-form-urlencoded",
+              Accept: "application/json",
             },
-            'rejectUnauthorized': node.rejectUnauthorized,
+            rejectUnauthorized: node.rejectUnauthorized,
             form: {
-              'grant_type': node.grant_type,
-              'scope': node.scope
-            }
+              grant_type: node.grant_type,
+              scope: node.scope,
+            },
           };
           if (node.grant_type === "password") {
             options.form.username = node.username;
             options.form.password = node.password;
-          };
+          }
           if (node.grant_type === "authorization_code") {
             // Some services accept these via Authorization while other require it in the POST body
             if (node.client_credentials_in_body) {
@@ -143,8 +182,8 @@ module.exports = function (RED) {
             const credentials = RED.nodes.getCredentials(this.id);
             options.form.code = credentials.code;
             options.form.redirect_uri = credentials.redirectUri;
-          };
-        };
+          }
+        }
 
         // add any custom headers, if we haven't already set them above
         if (oauth2Node.headers) {
@@ -157,7 +196,9 @@ module.exports = function (RED) {
 
         if (this.noprox) {
           for (let i = 0; i < this.noprox.length; i += 1) {
-            if (url.indexOf(this.noprox[i]) !== -1) { this.noproxy = true; }
+            if (url.indexOf(this.noprox[i]) !== -1) {
+              this.noproxy = true;
+            }
           }
         }
         if (this.prox && !this.noproxy) {
@@ -172,16 +213,16 @@ module.exports = function (RED) {
                 hostname: proxyURL.hostname,
                 port: proxyURL.port,
                 username: null,
-                password: null
+                password: null,
               },
               maxFreeSockets: 256,
               maxSockets: 256,
               //getCert: for reliably retrieving the peer certificate, we must use agents with keepAlive=false
-              keepAlive: false
-            }
+              keepAlive: false,
+            };
             if (proxyConfig && proxyConfig.credentials) {
-              let proxyUsername = proxyConfig.credentials.username || '';
-              let proxyPassword = proxyConfig.credentials.password || '';
+              let proxyUsername = proxyConfig.credentials.username || "";
+              let proxyPassword = proxyConfig.credentials.password || "";
               if (proxyUsername || proxyPassword) {
                 proxyOptions.proxy.username = proxyUsername;
                 proxyOptions.proxy.password = proxyPassword;
@@ -198,33 +239,56 @@ module.exports = function (RED) {
         }
         delete msg.oauth2Request;
         // make a post request
-        axios.post(options.url, options.form, {
-          headers: options.headers,
-          proxy: this.proxy,
-          httpsAgent: node.rejectUnauthorized ? new https.Agent({ rejectUnauthorized: true }) : new https.Agent({ rejectUnauthorized: false }),
-        })
-          .then(response => {
+        axios
+          .post(options.url, options.form, {
+            headers: options.headers,
+            proxy: this.proxy,
+            httpsAgent: node.rejectUnauthorized
+              ? new https.Agent({ rejectUnauthorized: true })
+              : new https.Agent({ rejectUnauthorized: false }),
+          })
+          .then((response) => {
             msg[node.container] = response.data || {};
             if (response.status === 200) {
-              node.status({ fill: "green", shape: "dot", text: `HTTP ${response.status}, ok` });
+              node.status({
+                fill: "green",
+                shape: "dot",
+                text: `HTTP ${response.status}, ok`,
+              });
             } else {
-              node.status({ fill: "yellow", shape: "dot", text: `HTTP ${response.status}, nok` });
+              node.status({
+                fill: "yellow",
+                shape: "dot",
+                text: `HTTP ${response.status}, nok`,
+              });
             }
-            nodeSend(msg);
-            nodeDone();
+            Send(msg);
+            Done();
           })
-          .catch(error => {
-            msg[node.container] = error.response ? error.response.data || {} : {};
-            node.status({ fill: "red", shape: "dot", text: `ERR ${error.code}` });
+          .catch((error) => {
+            msg[node.container] = error.response
+              ? error.response.data || {}
+              : {};
+            node.status({
+              fill: "red",
+              shape: "dot",
+              text: `ERR ${error.code}`,
+            });
             if (!this.sendErrorsToCatch) {
-              nodeSend(msg);
+              Send(msg);
             }
-            nodeDone();
+            Done();
           });
       });
     }
-  };
+  }
 
+  /**
+   * Registers an OAuth2Node node type with credentials object
+   * @param {string} "oauth2-credentials" - the name of the node type to register
+   * @param {OAuth2Node} OAuth2Node - the constructor function for the node type
+   * @param {object} {credentials: {...}} - an object specifying the credentials properties and their types
+   */
   RED.nodes.registerType("oauth2-credentials", OAuth2Node, {
     credentials: {
       displayName: { type: "text" },
@@ -235,18 +299,30 @@ module.exports = function (RED) {
       expireTime: { type: "password" },
       code: { type: "password" },
       proxy: { type: "json" },
-    }
+    },
   });
 
-
-  RED.httpAdmin.get('/oauth2/credentials/:token', function (req, res) {
+  /**
+   * Endpoint to retrieve OAuth2 credentials based on a token
+   * @param {Object} req - The HTTP request object
+   * @param {Object} res - The HTTP response object
+   */
+  RED.httpAdmin.get("/oauth2/credentials/:token", function (req, res) {
     const credentials = RED.nodes.getCredentials(req.params.token);
-    res.json({ code: credentials.code, redirect_uri: credentials.redirect_uri });
+    res.json({
+      code: credentials.code,
+      redirect_uri: credentials.redirect_uri,
+    });
   });
 
-  RED.httpAdmin.get('/oauth2/redirect', function (req, res) {
+  /**
+   * Handles GET requests to /oauth2/redirect
+   * @param {object} req - the HTTP request object
+   * @param {object} res - the HTTP response object
+   */
+  RED.httpAdmin.get("/oauth2/redirect", function (req, res) {
     if (req.query.code) {
-      const state = req.query.state.split(':');
+      const state = req.query.state.split(":");
       const node_id = state[0];
       const credentials = RED.nodes.getCredentials(node_id);
       credentials.code = req.query.code;
@@ -272,9 +348,18 @@ module.exports = function (RED) {
     }
   });
 
-  RED.httpAdmin.get('/oauth2/auth', async function (req, res) {
-    if (!req.query.clientId || !req.query.clientSecret ||
-      !req.query.id || !req.query.callback) {
+  /**
+   * Endpoint to handle the OAuth2 authorization code flow
+   * @param {Object} req - The HTTP request object
+   * @param {Object} res - The HTTP response object
+   */
+  RED.httpAdmin.get("/oauth2/auth", async function (req, res) {
+    if (
+      !req.query.clientId ||
+      !req.query.clientSecret ||
+      !req.query.id ||
+      !req.query.callback
+    ) {
       res.sendStatus(400);
       return;
     }
@@ -282,7 +367,9 @@ module.exports = function (RED) {
     const node_id = req.query.id;
     const callback = req.query.callback;
     const redirectUri = req.query.redirectUri;
-    const credentials = JSON.parse(JSON.stringify(req.query, getCircularReplacer()));
+    const credentials = JSON.parse(
+      JSON.stringify(req.query, getCircularReplacer())
+    );
     const proxy = RED.nodes.getNode(credentials.proxy);
 
     let proxyOptions;
@@ -297,23 +384,27 @@ module.exports = function (RED) {
           hostname: proxyURL.hostname,
           port: proxyURL.port,
           username: proxyURL.username,
-          password: proxyURL.password
+          password: proxyURL.password,
         };
       }
     }
 
     const scope = req.query.scope;
-    const csrfToken = crypto.randomBytes(18).toString('base64').replace(/\//g, '-').replace(/\+/g, '_');
+    const csrfToken = crypto
+      .randomBytes(18)
+      .toString("base64")
+      .replace(/\//g, "-")
+      .replace(/\+/g, "_");
 
     credentials.csrfToken = csrfToken;
     credentials.callback = callback;
     credentials.redirectUri = redirectUri;
 
-    res.cookie('csrf', csrfToken);
+    res.cookie("csrf", csrfToken);
 
     var l = url.parse(req.query.authorizationEndpoint, true);
     const redirectUrl = url.format({
-      protocol: l.protocol.replace(':', ''),
+      protocol: l.protocol.replace(":", ""),
       hostname: l.hostname,
       port: l.port,
       pathname: l.pathname,
@@ -322,13 +413,13 @@ module.exports = function (RED) {
         redirect_uri: redirectUri,
         state: node_id + ":" + csrfToken,
         scope: scope,
-        response_type: 'code'
-      }
+        response_type: "code",
+      },
     });
 
     try {
       const response = await axios.get(redirectUrl, {
-        proxy: proxyOptions
+        proxy: proxyOptions,
       });
       res.redirect(response.request.res.responseUrl);
 
@@ -338,11 +429,19 @@ module.exports = function (RED) {
     }
   });
 
-  RED.httpAdmin.get('/oauth2/auth/callback', function (req, res) {
+  /**
+   * Endpoint to handle the OAuth2 authorization callback
+   * @param {Object} req - The HTTP request object
+   * @param {Object} res - The HTTP response object
+   */
+  RED.httpAdmin.get("/oauth2/auth/callback", function (req, res) {
     if (req.query.error) {
-      return res.send("oauth2.error.error", { error: req.query.error, description: req.query.error_description });
+      return res.send("oauth2.error.error", {
+        error: req.query.error,
+        description: req.query.error_description,
+      });
     }
-    var state = req.query.state.split(':');
+    var state = req.query.state.split(":");
     var node_id = state[0];
     var credentials = RED.nodes.getCredentials(node_id);
     if (!credentials || !credentials.clientId || !credentials.clientSecret) {
@@ -351,7 +450,6 @@ module.exports = function (RED) {
     if (state[1] !== credentials.csrfToken) {
       return res.status(401).send("oauth2.error.token-mismatch");
     }
-
   });
   RED.nodes.registerType("oauth2", OAuth2Node);
 };

--- a/oauth2.js
+++ b/oauth2.js
@@ -242,9 +242,9 @@ module.exports = function (RED) {
           const response = axios.post(options.url, options.form, {
             headers: options.headers,
             proxy: node.proxy,
-            httpsAgent: node.rejectUnauthorized
-              ? new https.Agent({ rejectUnauthorized: true })
-              : new https.Agent({ rejectUnauthorized: false }),
+            httpsAgent: new https.Agent({
+              rejectUnauthorized: node.rejectUnauthorized,
+            }),
           });
           return response;
         };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3945941/229898212-dd302692-4ee5-421a-9441-24a2a8724f75.png)

The `oauth2.json` file has been updated to include new keys `use-proxy`, `proxy-config`, and `senderr`. 
In the `oauth2.html` file, a new form field is added for Proxy Configuration with two sub-fields - `Use proxy` and `Proxy Configuration`.

### In the oauth2.js file, the following changes were made:
* New constants axios and httpsProxyAgent are imported, which seems to be used to provide support for proxy configuration. Looks good.
* The oauth2Request function is updated to add support for proxy configuration, which looks fine.
* The handleResponse function is updated to send non-2xx responses to the Catch node when senderr option is enabled, which looks good.
* The oauth2 node is updated to handle the use-proxy and proxy options when they are enabled, which seems fine.
