### PR TITLE
Add force token refresh option to OAuth2 configuration

### DIFF
--- a/src/locales/en-US/oauth2.json
+++ b/src/locales/en-US/oauth2.json
@@ -4,7 +4,8 @@
     "tips": {
       "debug": "Check the box to enable debug mode with extra logs.",
       "client_credentials_in_body": "Ensure that the client credentials are included in the token request body for authentication purposes.",
-      "rejectUnauthorized": "The rejectUnauthorized parameter controls SSL/TLS certificate validation for the server, with true enforcing validation and false disabling it."
+      "rejectUnauthorized": "The rejectUnauthorized parameter controls SSL/TLS certificate validation for the server, with true enforcing validation and false disabling it.",
+      "force": "Use the Force option to generate a new access token even if the current token is still valid. This is useful for ensuring that your token is always fresh, especially if there are changes in scopes or permissions, or if you encounter authentication issues."
     },
     "label": {
       "debug": "Debug Mode.",
@@ -30,7 +31,8 @@
       "proxy-config": "Proxy Configuration",
       "use-proxy": "Use proxy",
       "senderr": "Only send non-2xx responses to Catch node",
-      "refresh_token": "Refresh Token"
+      "refresh_token": "Refresh Token",
+      "force": "Force Token Refresh"
     },
     "placeholder": {
       "name": "oauth2",

--- a/src/oauth2.html
+++ b/src/oauth2.html
@@ -119,6 +119,16 @@
       </div>
    </div>
 
+      <!-- node-force -->
+      <div class="form-row">
+         <input type="checkbox" id="node-input-force" style="display: inline-block; width: auto; vertical-align: top;" />
+         <label for="node-input-force" style="width:auto;"><i class="fa fa-sign-in fa-fw"></i> <span data-i18n="oauth2.label.force"></span></label>
+         <div abria-label="Info for context store" class="form-row form-tips node-help" style="width:100%">
+            <i class="fa fa-exclamation-circle fa-fw"></i><b>Force Token Refresh</b> -
+            <span data-i18n="oauth2.tips.force"></span>
+         </div>
+      </div>
+
    <!-- node-client_credentials_in_body -->
    <div class="form-row" id="node-client_credentials_in_body">
       <input type="checkbox" id="node-input-client_credentials_in_body" autocomplete="on" style="display: inline-block; width: auto; vertical-align: top;" checked />
@@ -208,6 +218,7 @@
                label: RED._('node-red:oauth2.label.proxy-config')
             },
             debug: { value: false },
+            force: { value: false },
             senderr: { value: false },
             client_credentials_in_body: { value: false },
             rejectUnauthorized: { value: true },


### PR DESCRIPTION
 This commit introduces a new feature to the OAuth2 configuration that allows users to force a token refresh. This can be particularly useful when there are changes in scopes or permissions, or when
 authentication issues are encountered.

 Changes include:
 - Added a new checkbox in the OAuth2 HTML configuration for the 'Force Token Refresh' option.
 - Updated the OAuth2 JSON locale files to include descriptions and labels for the new 'force' option.
 - Modified the OAuth2 JavaScript to handle the 'force' configuration, ensuring that a new access token is generated when this option is enabled, regardless of the current token's validity.
 - Improved the handling of the OAuth2 response and headers in the message object.
 - Refactored the `shouldBypassProxy` function for clarity.
 - Streamlined the success page HTML response for the OAuth2 callback endpoint.

 The new 'force' option is now available in the node configuration UI, and users can enable it to ensure that a fresh access token is always used.
