### PR TITLE
Fixed bug where the returned `expires_in` is used as string

### DIFF
--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -344,7 +344,7 @@ module.exports = function (RED) {
          this.setStatus('green', `HTTP ${response.status}, ok`);
          this.logger.debug('handleResponse: Response data set in message', msg);
 
-         const expireTime = Math.floor(Date.now() / 1000) + (response.data.expires_in || 3600);
+         const expireTime = Math.floor(Date.now() / 1000) + parseInt(response.data.expires_in || 3600);
          this.credentials.access_token = response.data.access_token;
          this.credentials.expire_time = expireTime;
          this.credentials = { ...this.credentials, oauth2Response: msg.oauth2Response, headers: msg.headers };


### PR DESCRIPTION
Fixed bug where the returned `expires_in` for `access_token` was used as string. As a result incorrect expireTime is calculated and the `access_token` would never expire
